### PR TITLE
feat: add npm publishing via gh workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: publish to npm
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "svelte": "src/DevTools.svelte",
   "module": "index.mjs",
   "version": "0.0.1",
-  "description": "component",
+  "description": "dev tools for web apps ",
   "main": "index.js",
   "author": "Mila Frerichs <mila.frerichs@gmail.com>",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "build": "rollup -c",
     "autobuild": "rollup -c example/rollup.config.js -w",
     "start:dev": "sirv example/public --dev -p 1313",
-    "prepublishOnly": "npm run srcdoc && npm run build",
+    "prepublishOnly": "npm run build",
     "start": "run-p start:dev autobuild",
     "test": "jest",
     "test:watch": "npm run test -- --watch"
@@ -50,16 +50,12 @@
       "js",
       "svelte"
     ],
-    "setupFiles": [
-      "jest-canvas-mock"
-    ],
     "setupFilesAfterEnv": [
       "@testing-library/jest-dom/extend-expect"
     ]
   },
   "files": [
     "src",
-    "scripts",
     "index.mjs",
     "index.js"
   ]


### PR DESCRIPTION
## Description
When you create a release on gh publish the package to npm

clean up package.json while we're at it.